### PR TITLE
Use consistent hash syntax, and make devise views generic and removing legacy cruft that snuck in

### DIFF
--- a/files/app/views/devise/confirmations/new.html.haml
+++ b/files/app/views/devise/confirmations/new.html.haml
@@ -1,9 +1,8 @@
 %h2 Resend confirmation instructions
-= simple_form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f|
+= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
   = f.error_notification
   = f.full_error :confirmation_token
   .form-inputs
-    = f.input :email, :required => true, :autofocus => true
+    = f.input :email, required: true, autofocus: true
   .form-actions
     = f.button :submit, "Resend confirmation instructions"
-

--- a/files/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/files/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,4 +1,4 @@
 %p
   Welcome #{@email}!
 %p You can confirm your account email through the link below:
-%p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token)
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/files/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/files/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,6 +1,6 @@
 %p
   Hello #{@resource.email}!
 %p Someone has requested a link to change your password. You can do this through the link below.
-%p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token)
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
 %p If you didn't request this, please ignore this email.
 %p Your password won't change until you access the link above and create a new one.

--- a/files/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/files/app/views/devise/mailer/unlock_instructions.html.haml
@@ -2,4 +2,4 @@
   Hello #{@resource.email}!
 %p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
 %p Click the link below to unlock your account:
-%p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token)
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/files/app/views/devise/passwords/edit.html.haml
+++ b/files/app/views/devise/passwords/edit.html.haml
@@ -1,11 +1,11 @@
 %h2 Change your password
-= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   = f.error_notification
-  = f.input :reset_password_token, :as => :hidden
+  = f.input :reset_password_token, as: :hidden
   = f.full_error :reset_password_token
   .form-inputs
-    = f.input :password, :label => "New password", :required => true, :autofocus => true
-    = f.input :password_confirmation, :label => "Confirm your new password", :required => true
+    = f.input :password, label: "New password", required: true, autofocus: true
+    = f.input :password_confirmation, label: "Confirm your new password", required: true
   .form-actions
     = f.button :submit, "Change my password"
 

--- a/files/app/views/devise/passwords/new.html.haml
+++ b/files/app/views/devise/passwords/new.html.haml
@@ -2,23 +2,23 @@
   .container
     .row
       .col-md-8.col-md-offset-2
-        = simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|{:role => 'form'}
-          .well.client-users-canvas
-            .client-users-inputs
+        = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| { role: 'form'}
+          .well{ class: "#{resource_name}-canvas" }
+            %div{ class: "#{resource_name}-inputs" }
               .row
                 .col-md-12.visible-xs
                   .xs-brand
-                    = image_tag 'temporary-static-assets/logo-beats_186x50.png', class: 'client-brand-logo', alt: current_brand.name, height: '25px'
+                    = image_tag 'logo.png', class: 'logo', alt: Rails.application.class.parent_name.titleize, height: '25px'
               .row
                 .col-md-8
                   .left-col
                     = f.error_notification
-                    %label{:for => 'client_user_email'} Forget your password?
-                    = f.input :email, :required => false, :autofocus => true, :label => false, :placeholder => 'Enter Your Email', :input_html => {:class => 'form-control'}
+                    %label{for: "#{resource_name}_email"} Forget your password?
+                    = f.input :email, required: false, autofocus: true, label: false, placeholder: 'Enter Your Email'
                 .col-md-4.hidden-xs
                   .right-col
-                    = image_tag 'temporary-static-assets/logo-beats_186x50.png', class: 'client-brand-logo', alt: current_brand.name, height: '25px'
-            .client-users-actions
+                    = image_tag 'logo.png', class: 'logo', alt: Rails.application.class.parent_name.titleize, height: '25px'
+            %div{ class: "#{resource_name}-actions" }
               .row
                 .col-md-12
-                  = f.button :submit, "Email reset instructions", :class => 'btn btn-sm btn-primary'
+                  = f.button :submit, "Email reset instructions", class: 'btn btn-sm btn-primary'

--- a/files/app/views/devise/registrations/edit.html.haml
+++ b/files/app/views/devise/registrations/edit.html.haml
@@ -1,18 +1,14 @@
 %h2
   Edit #{resource_name.to_s.humanize}
-= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f|
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = f.error_notification
   .form-inputs
-    = f.input :email, :required => true, :autofocus => true
+    = f.input :email, required: true, autofocus: true
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %p
         Currently waiting confirmation for: #{resource.unconfirmed_email}
-    = f.input :password, :autocomplete => "off", :hint => "leave it blank if you don't want to change it", :required => false
-    = f.input :password_confirmation, :required => false
-    = f.input :current_password, :hint => "we need your current password to confirm your changes", :required => true
+    = f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false
+    = f.input :password_confirmation, required: false
+    = f.input :current_password, hint: "we need your current password to confirm your changes", required: true
   .form-actions
     = f.button :submit, "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{link_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete}
-= link_to "Back", :back

--- a/files/app/views/devise/registrations/new.html.haml
+++ b/files/app/views/devise/registrations/new.html.haml
@@ -1,10 +1,29 @@
-%h2 Sign up
-= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f|
-  = f.error_notification
-  .form-inputs
-    = f.input :email, :required => true, :autofocus => true
-    = f.input :password, :required => true
-    = f.input :password_confirmation, :required => true
-  .form-actions
-    = f.button :submit, "Sign up"
+%section#sign-up
+  .container
+    .row
+      .col-md-8.col-md-offset-2
+        %h2 Sign Up
+    .row
+      .col-md-8.col-md-offset-2
+        = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| { role: 'form' }
+          .well{ class: "#{resource_name}-canvas" }
+            = f.error_notification
+            %div{ class: "#{resource_name}-inputs" }
+              .row
+                .col-md-12.visible-xs
+                  .xs-brand
+                    = image_tag 'logo.png', class: 'logo', alt: Rails.application.class.parent_name.titleize, height: '25px'
+              .row
+                .col-md-8
+                  .left-col
+                    = f.input :email, required: true, autofocus: true, placeholder: 'Enter Your Email'
+                    = f.input :password, required: true, placeholder: 'Enter Your Password'
+                    = f.input :password_confirmation, required: true, placeholder: 'Confirm Your Password'
+                .col-md-4.hidden-xs
+                  .right-col
+                    = image_tag 'logo.png', class: 'logo', alt: Rails.application.class.parent_name.titleize, height: '25px'
 
+            %div{ class: "#{resource_name}-actions" }
+              .row
+                .col-md-12
+                  = f.button :submit, "Sign up", class: 'btn btn-sm btn-primary'

--- a/files/app/views/devise/sessions/new.html.haml
+++ b/files/app/views/devise/sessions/new.html.haml
@@ -2,9 +2,9 @@
   .container
     .row
       .col-md-8.col-md-offset-2
-        = simple_form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|{:role => 'form'}
-          .well.client-users-canvas
-            .client-users-inputs
+        = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| { role: 'form' }
+          .well{ class: "#{resource_name}-canvas" }
+            %div{ class: "#{resource_name}-inputs" }
               .row
                 .col-md-12.visible-xs
                   .xs-brand
@@ -12,17 +12,15 @@
               .row
                 .col-md-8
                   .left-col
-                    .form-group
-                      = f.input :email, :required => false, :autofocus => true, :placeholder => 'Enter Your Email', :input_html => {:class => 'form-control'}
-                    .form-group
-                      = f.input :password, :required => false, :placeholder => 'Enter Your Password', :input_html => {:class => 'form-control'}
-                    .checkbox
-                      = f.input :remember_me, :as => :boolean, :label => false, :inline_label => true if devise_mapping.rememberable?
+                    = f.input :email, required: false, autofocus: true, placeholder: 'Enter Your Email'
+                    = f.input :password, required: false, placeholder: 'Enter Your Password'
+                    = f.input :remember_me, :as => :boolean, :label => false, :inline_label => 'Remember Me' if devise_mapping.rememberable?
+                    -#= f.input :remember_me, as: :boolean, label: 'Remember me', wrapper: :inline_checkbox if devise_mapping.rememberable?
                 .col-md-4.hidden-xs
                   .right-col
                     = image_tag 'logo.png', class: 'logo', alt: Rails.application.class.parent_name.titleize, height: '25px'
 
-            .client-users-actions
+            %div{ class: "#{resource_name}-actions" }
               .row
                 .col-md-12
-                  = f.button :submit, "Sign in", :class => 'btn btn-sm btn-primary'
+                  = f.button :submit, "Sign in", class: 'btn btn-sm btn-primary'

--- a/files/app/views/devise/unlocks/new.html.haml
+++ b/files/app/views/devise/unlocks/new.html.haml
@@ -1,9 +1,9 @@
 %h2 Resend unlock instructions
-= simple_form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f|
+= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
   = f.error_notification
   = f.full_error :unlock_token
   .form-inputs
-    = f.input :email, :required => true, :autofocus => true
+    = f.input :email, required: true, autofocus: true
   .form-actions
     = f.button :submit, "Resend unlock instructions"
 


### PR DESCRIPTION
Not all the views are styled properly yet, but at least this gets us away from having accidental app-specific items in the devise views.
